### PR TITLE
Mise à jour 19w04g

### DIFF
--- a/data/commandes/functions/cmd_effects.mcfunction
+++ b/data/commandes/functions/cmd_effects.mcfunction
@@ -2,7 +2,7 @@
 # Cette fonction gère l'attribution des effets à donner en fonction des commandes effectuées.
 #
 # Mode de déclenchament : tick
-# Déclencheur(s) : "tick.mcfunction"
+# Déclencheur(s) : "minecraft:tick"
 #
 # Tags utilisés :
 #

--- a/data/commandes/functions/cmd_effects.mcfunction
+++ b/data/commandes/functions/cmd_effects.mcfunction
@@ -1,5 +1,5 @@
 # ==================================================================================================
-# Cette fonction gère l'attribution des effets à donner en fonction des commandes effectuées.
+# Cette fonction gère les effets donnés en fonction des commandes effectuées.
 #
 # Mode de déclenchament : tick
 # Déclencheur(s) : "minecraft:tick"
@@ -10,3 +10,8 @@
 
 # Vanish
 effect give @a[tag=isVanish] invisibility 1 255 true
+
+# Helpop
+execute if entity @a[tag=helpOped] if score cmdHelpopMessage cmdHelpopMessage matches 1200.. run tellraw @a ["",{"text":"§7§lServeur » §r"},{"selector":"@a[tag=helpOped]"},{"text":" a(ont) besoin d'aide !","color":"red"}]
+execute if entity @a[tag=helpOped] if score cmdHelpopMessage cmdHelpopMessage matches 1200.. run scoreboard players reset cmdHelpopMessage
+execute if entity @a[tag=helpOped] unless score cmdHelpopMessage cmdHelpopMessage matches 1200.. run scoreboard players add cmdHelpopMessage cmdHelpopMessage 1

--- a/data/commandes/functions/cmd_effects.mcfunction
+++ b/data/commandes/functions/cmd_effects.mcfunction
@@ -8,10 +8,13 @@
 #
 # ==================================================================================================
 
-# Vanish
-effect give @a[tag=isVanish] invisibility 1 255 true
+# God
+execute as @a[tag=isGod] run function commun:outils/protection
 
 # Helpop
 execute if entity @a[tag=helpOped] if score cmdHelpopMessage cmdHelpopMessage matches 1200.. run tellraw @a ["",{"text":"§7§lServeur » §r"},{"selector":"@a[tag=helpOped]"},{"text":" a(ont) besoin d'aide !","color":"red"}]
 execute if entity @a[tag=helpOped] if score cmdHelpopMessage cmdHelpopMessage matches 1200.. run scoreboard players reset cmdHelpopMessage
 execute if entity @a[tag=helpOped] unless score cmdHelpopMessage cmdHelpopMessage matches 1200.. run scoreboard players add cmdHelpopMessage cmdHelpopMessage 1
+
+# Vanish
+effect give @a[tag=isVanish] invisibility 1 255 true

--- a/data/commandes/functions/cmd_joueurs.mcfunction
+++ b/data/commandes/functions/cmd_joueurs.mcfunction
@@ -1,0 +1,22 @@
+# ==================================================================================================
+# Cette fonction gère l'execution des toutes les commandes personnalisées des joueurs.
+#
+# Mode de déclenchament : tick
+# Déclencheur(s) : "minecraft:tick"
+#
+# Tags utilisés :
+#
+# ==================================================================================================
+
+# 1 - Bug : Donne le lien vers le report de bug sur GitHub
+execute if score @s cmdRunCmd matches 1 run tellraw @s ["",{"text":"§7§lServeur » §r"},{"text":"Merci de rapporter les bugs que tu as trouvé ici :","color":"green","clickEvent":{"action":"open_url","value":"https://github.com/Aycraft/Aycraft_1.14/issues"}},{"text":" ","clickEvent":{"action":"open_url","value":"https://github.com/Aycraft/Aycraft_1.14/issues"}},{"text":"https://github.com/Aycraft/Aycraft_1.14/issues","color":"blue","clickEvent":{"action":"open_url","value":"https://github.com/Aycraft/Aycraft_1.14/issues"}}]
+execute if score @s cmdRunCmd matches 1 run scoreboard players set @s cmdRunCmd 0
+
+# 2 - Hub : Téléporte l'executeur au spawn
+execute if score @s cmdRunCmd matches 2 run function commandes:joueurs/hub
+
+# 3 - Helpop : Envoie un message régulièrement aux membres du staff pour indiquer que le joueur veut de l'aide
+
+# Réinitialisation du score de detection de l'execution d'une commande par un joueur
+execute if score @s cmdRunCmd matches 1.. run tellraw @s ["",{"text":"§7§lServeur » §r"},{"text":"Cette commande n'existe pas","color":"red"}]
+scoreboard players reset @s cmdRunCmd

--- a/data/commandes/functions/cmd_joueurs.mcfunction
+++ b/data/commandes/functions/cmd_joueurs.mcfunction
@@ -16,6 +16,7 @@ execute if score @s cmdRunCmd matches 1 run scoreboard players set @s cmdRunCmd 
 execute if score @s cmdRunCmd matches 2 run function commandes:joueurs/hub
 
 # 3 - Helpop : Envoie un message régulièrement aux membres du staff pour indiquer que le joueur veut de l'aide
+execute if score @s cmdRunCmd matches 3 run function commandes:joueurs/helpop
 
 # Réinitialisation du score de detection de l'execution d'une commande par un joueur
 execute if score @s cmdRunCmd matches 1.. run tellraw @s ["",{"text":"§7§lServeur » §r"},{"text":"Cette commande n'existe pas","color":"red"}]

--- a/data/commandes/functions/cmd_staff.mcfunction
+++ b/data/commandes/functions/cmd_staff.mcfunction
@@ -1,5 +1,5 @@
 # ==================================================================================================
-# Cette fonction gère l'execution des toutes les commandes personnalisées.
+# Cette fonction gère l'execution des toutes les commandes personnalisées du staff.
 #
 # Mode de déclenchament : tick
 # Déclencheur(s) : "minecraft:tick"
@@ -13,14 +13,14 @@ execute unless score @s statsGrade matches 10.. run scoreboard players set @s cm
 execute if score @s cmdRunStaffCmd matches 0 run tellraw @s ["",{"text":"§7§lServeur » §r"},{"text":"Vous n'avez pas accès à cette commande","color":"red"}]
 execute if score @s cmdRunStaffCmd matches 0 run scoreboard players reset @s cmdRunStaffCmd
 
-# 1 - Clearchat : Vide tout le chat pour tous les joueurs (seulement le staff)
+# 1 - Clearchat : Vide tout le chat pour tous les joueurs
 execute if score @s cmdRunStaffCmd matches 1 run function commandes:staff/clearchat
 
 # 3 - Freeze <player>(id) : Immobiliser un joueur
 # 4 - God : Se rendre invincible
 # 5 - Modotools : Obtenir les objets de modération
 
-# 6 - Vanish : Disparaître (seulement le staff)
+# 6 - Vanish : Disparaître
 execute if score @s cmdRunStaffCmd matches 6 run function commandes:staff/vanish
 
 # Réinitialisation du score de detection de l'execution d'une commande par un joueur

--- a/data/commandes/functions/cmd_staff.mcfunction
+++ b/data/commandes/functions/cmd_staff.mcfunction
@@ -18,8 +18,9 @@ execute if score @s cmdRunStaffCmd matches 1 run function commandes:staff/clearc
 
 # 3 - Freeze <player>(id) : Immobiliser un joueur
 # 4 - God : Se rendre invincible
-# 5 - Modotools : Obtenir les objets de modération
+execute if score @s cmdRunStaffCmd matches 4 run function commandes:staff/god
 
+# 5 - Modotools : Obtenir les objets de modération
 # 6 - Vanish : Disparaître
 execute if score @s cmdRunStaffCmd matches 6 run function commandes:staff/vanish
 

--- a/data/commandes/functions/joueurs/helpop.mcfunction
+++ b/data/commandes/functions/joueurs/helpop.mcfunction
@@ -1,0 +1,22 @@
+# ==================================================================================================
+# Cette fonction gère la demande d'aide au personnel.
+#
+# Mode de déclenchament : event
+# Déclencheur(s) : "commandes:cmd_joueurs"
+#
+# Tags utilisés :
+#
+# ==================================================================================================
+
+# Messages
+tellraw @s[tag=!helpOped] ["",{"text":"§7§lServeur » §r"},{"text":"Vous avez demandé de l'aide au personnel, veuillez patienter que quelqu'un vienne vous aider...","color":"green"}]
+tellraw @s[tag=helpOped] ["",{"text":"§7§lServeur » §r"},{"text":"Vous avez retiré votre demande d'aide au personnel.","color":"red"}]
+
+# Modifications du tag
+tag @s[tag=helpOped] add unHelpOped
+tag @s[tag=!helpOped] add helpOped
+tag @s[tag=unHelpOped] remove helpOped
+tag @s[tag=unHelpOped] remove unHelpOped
+
+# Réinitialisation du score qui detecte la commande
+scoreboard players set @s cmdRunCmd 0

--- a/data/commandes/functions/joueurs/helpop.mcfunction
+++ b/data/commandes/functions/joueurs/helpop.mcfunction
@@ -5,7 +5,8 @@
 # Déclencheur(s) : "commandes:cmd_joueurs"
 #
 # Tags utilisés :
-#
+# 1 - "helpOped"
+# 2 - "unHelpOped"
 # ==================================================================================================
 
 # Messages

--- a/data/commandes/functions/joueurs/hub.mcfunction
+++ b/data/commandes/functions/joueurs/hub.mcfunction
@@ -13,7 +13,7 @@
 # Téléportation
 function commun:outils/teleportation_options
 tp @s 0 1 0 0 0
-tellraw @s ["",{"text":"§7§lServeur » §r"},{"text":"Vous avez été téléporté(e) au hub","color":"red"}]
+tellraw @s ["",{"text":"§7§lServeur » §r"},{"text":"Vous avez été téléporté(e) au hub","color":"green"}]
 
 # Réinitialisation du score qui detecte la commande
 scoreboard players set @s cmdRunCmd 0

--- a/data/commandes/functions/joueurs/hub.mcfunction
+++ b/data/commandes/functions/joueurs/hub.mcfunction
@@ -1,0 +1,19 @@
+# ==================================================================================================
+# Cette fonction gère la téléportation au spawn.
+#
+# Mode de déclenchament : tick
+# Déclencheur(s) : "commandes:cmd_joueurs"
+#
+# Tags utilisés :
+#
+# ==================================================================================================
+
+# Vérification avant la téléportation
+
+# Téléportation
+function commun:outils/teleportation_options
+tp @s 0 1 0 0 0
+tellraw @s ["",{"text":"§7§lServeur » §r"},{"text":"Vous avez été téléporté(e) au hub","color":"red"}]
+
+# Réinitialisation du score qui detecte la commande
+scoreboard players set @s cmdRunCmd 0

--- a/data/commandes/functions/load.mcfunction
+++ b/data/commandes/functions/load.mcfunction
@@ -3,7 +3,7 @@
 # Il appellera les fonctions du fichier "load".
 #
 # Type d'activation : load
-# Activateur(s) : "load.json"
+# Activateur(s) : "minecraft:load"
 #
 # Tag(s) utilisé(s) :
 #

--- a/data/commandes/functions/load/scores.mcfunction
+++ b/data/commandes/functions/load/scores.mcfunction
@@ -2,7 +2,7 @@
 # Cette fonction crée tous les scores relatifs aux commandes personalisées.
 #
 # Type d'activation : load
-# Activateur(s) : "load.mcfunction"
+# Activateur(s) : "commandes:load"
 #
 # Tag(s) utilisé(s) :
 #

--- a/data/commandes/functions/load/scores.mcfunction
+++ b/data/commandes/functions/load/scores.mcfunction
@@ -15,3 +15,4 @@ tellraw @a ["",{"text":"§7§lServeur » §r"},{"text":"Initialisation des score
 # Scores
 scoreboard objectives add cmdRunCmd trigger
 scoreboard objectives add cmdRunStaffCmd trigger
+scoreboard objectives add cmdHelpopMessage dummy

--- a/data/commandes/functions/staff/clearchat.mcfunction
+++ b/data/commandes/functions/staff/clearchat.mcfunction
@@ -2,7 +2,7 @@
 # Cette fonction sert à vider le chat de tous les joueurs.
 #
 # Mode de déclenchament : event
-# Déclencheur(s) : "commandes:staff_cmd"
+# Déclencheur(s) : "commandes:cmd_staff"
 #
 # Tags utilisés :
 #

--- a/data/commandes/functions/staff/clearchat.mcfunction
+++ b/data/commandes/functions/staff/clearchat.mcfunction
@@ -2,7 +2,7 @@
 # Cette fonction sert à vider le chat de tous les joueurs.
 #
 # Mode de déclenchament : event
-# Déclencheur(s) : "cmd.mcfunction"
+# Déclencheur(s) : "commandes:staff_cmd"
 #
 # Tags utilisés :
 #

--- a/data/commandes/functions/staff/freeze.mcfunction
+++ b/data/commandes/functions/staff/freeze.mcfunction
@@ -2,7 +2,7 @@
 # Cette fonction sert à immobiliser un joueur.
 #
 # Mode de déclenchament : event
-# Déclencheur(s) : "commandes:staff_cmd"
+# Déclencheur(s) : "commandes:cmd_staff"
 #
 # Tags utilisés :
 #

--- a/data/commandes/functions/staff/freeze.mcfunction
+++ b/data/commandes/functions/staff/freeze.mcfunction
@@ -2,7 +2,7 @@
 # Cette fonction sert à immobiliser un joueur.
 #
 # Mode de déclenchament : event
-# Déclencheur(s) : "cmd.mcfunction"
+# Déclencheur(s) : "commandes:staff_cmd"
 #
 # Tags utilisés :
 #

--- a/data/commandes/functions/staff/god.mcfunction
+++ b/data/commandes/functions/staff/god.mcfunction
@@ -5,5 +5,20 @@
 # Déclencheur(s) : "commandes:cmd_staff"
 #
 # Tags utilisés :
-#
+# 1- "isGod"
+# 2- "disGod"
 # ==================================================================================================
+
+# Messages
+tellraw @s[tag=!isGod] ["",{"text":"§7§lServeur » §r"},{"text":"Vous êtes maintenant invulnérable","color":"green"}]
+tellraw @s[tag=isGod] ["",{"text":"§7§lServeur » §r"},{"text":"Vous êtes maintenant vulnérable","color":"red"}]
+
+# Modifications du tag
+tag @s[tag=isGod] add disGod
+tag @s[tag=!isGod] add isGod
+tag @s[tag=disGod] remove isGod
+tag @s[tag=disGod] remove disGod
+
+# Réinitialisation du score qui detecte la commande
+scoreboard players set @s cmdRunStaffCmd 0
+effect clear @s[tag=!isGod] invisibility

--- a/data/commandes/functions/staff/god.mcfunction
+++ b/data/commandes/functions/staff/god.mcfunction
@@ -2,7 +2,7 @@
 # Cette fonction sert à se rendre invincible.
 #
 # Mode de déclenchament : event
-# Déclencheur(s) : "commandes:staff_cmd"
+# Déclencheur(s) : "commandes:cmd_staff"
 #
 # Tags utilisés :
 #

--- a/data/commandes/functions/staff/god.mcfunction
+++ b/data/commandes/functions/staff/god.mcfunction
@@ -2,7 +2,7 @@
 # Cette fonction sert à se rendre invincible.
 #
 # Mode de déclenchament : event
-# Déclencheur(s) : "cmd.mcfunction"
+# Déclencheur(s) : "commandes:staff_cmd"
 #
 # Tags utilisés :
 #

--- a/data/commandes/functions/staff/modotools.mcfunction
+++ b/data/commandes/functions/staff/modotools.mcfunction
@@ -2,7 +2,7 @@
 # Cette fonction sert à obtenir les objets de modération.
 #
 # Mode de déclenchament : event
-# Déclencheur(s) : "commandes:staff_cmd"
+# Déclencheur(s) : "commandes:cmd_staff"
 #
 # Tags utilisés :
 #

--- a/data/commandes/functions/staff/modotools.mcfunction
+++ b/data/commandes/functions/staff/modotools.mcfunction
@@ -2,7 +2,7 @@
 # Cette fonction sert à obtenir les objets de modération.
 #
 # Mode de déclenchament : event
-# Déclencheur(s) : "cmd.mcfunction"
+# Déclencheur(s) : "commandes:staff_cmd"
 #
 # Tags utilisés :
 #

--- a/data/commandes/functions/staff/vanish.mcfunction
+++ b/data/commandes/functions/staff/vanish.mcfunction
@@ -2,7 +2,7 @@
 # Cette fonction sert à se rendre invisible.
 #
 # Mode de déclenchament : event
-# Déclencheur(s) : "commandes:staff_cmd"
+# Déclencheur(s) : "commandes:cmd_staff"
 #
 # Tags utilisés :
 # 1- "isVanish"

--- a/data/commandes/functions/staff/vanish.mcfunction
+++ b/data/commandes/functions/staff/vanish.mcfunction
@@ -2,7 +2,7 @@
 # Cette fonction sert à se rendre invisible.
 #
 # Mode de déclenchament : event
-# Déclencheur(s) : "cmd.mcfunction"
+# Déclencheur(s) : "commandes:staff_cmd"
 #
 # Tags utilisés :
 # 1- "isVanish"

--- a/data/commandes/functions/staff_cmd.mcfunction
+++ b/data/commandes/functions/staff_cmd.mcfunction
@@ -2,7 +2,7 @@
 # Cette fonction gère l'execution des toutes les commandes personnalisées.
 #
 # Mode de déclenchament : tick
-# Déclencheur(s) : "tick.mcfunction"
+# Déclencheur(s) : "minecraft:tick"
 #
 # Tags utilisés :
 #

--- a/data/commun/functions/connection.mcfunction
+++ b/data/commun/functions/connection.mcfunction
@@ -1,8 +1,8 @@
 # ==================================================================================================
-# Cette fonction gère la connection des joueurs.
+# Cette fonction gère la connection et l'attribution de l'UUID des joueurs.
 #
-# Mode de déclenchament : tick
-# Déclencheur(s) : "tick.mcfunction"
+# Mode de déclenchement : tick
+# Déclencheur(s) : "minecraft:tick"
 #
 # Tags utilisés :
 #
@@ -16,6 +16,7 @@ execute unless score @s UUID matches 1.. run function commun:outils/set_uuid
 
 # Connection
 execute if score @s leaveGame matches 1.. run function commun:outils/teleportation_options
+execute if score @s leaveGame matches 1.. run tp @s 0 1 0 0 0
 execute if score @s leaveGame matches 1.. run function commun:connection/messages
 execute if score @s leaveGame matches 1.. run function commun:connection/titles
 execute at @s if score @s leaveGame matches 1.. run function commun:connection/sons

--- a/data/commun/functions/connection/messages.mcfunction
+++ b/data/commun/functions/connection/messages.mcfunction
@@ -2,7 +2,7 @@
 # Cette fonction appelle les differents messages de connection des joueurs.
 #
 # Mode de déclenchament : event
-# Déclencheur(s) : "connection.mcfunction"
+# Déclencheur(s) : "commun:connection"
 #
 # Tags utilisés :
 #

--- a/data/commun/functions/connection/sons.mcfunction
+++ b/data/commun/functions/connection/sons.mcfunction
@@ -2,7 +2,7 @@
 # Cette fonction appelle les differents sons de connection des joueurs.
 #
 # Mode de déclenchament : event
-# Déclencheur(s) : "connection.mcfunction"
+# Déclencheur(s) : "commun:connection"
 #
 # Tags utilisés :
 #

--- a/data/commun/functions/connection/titles.mcfunction
+++ b/data/commun/functions/connection/titles.mcfunction
@@ -2,7 +2,7 @@
 # Cette fonction appelle les differents titres affichés lors de la connection des joueurs.
 #
 # Mode de déclenchament : event
-# Déclencheur(s) : "connection.mcfunction"
+# Déclencheur(s) : "commun:connection"
 #
 # Tags utilisés :
 #

--- a/data/commun/functions/load.mcfunction
+++ b/data/commun/functions/load.mcfunction
@@ -3,7 +3,7 @@
 # Il appellera les fonctions du fichier commun "load".
 #
 # Type d'activation : load
-# Activateur(s) : "load.json"
+# Activateur(s) : "minecraft:load"
 #
 # Tag(s) utilisé(s) :
 #

--- a/data/commun/functions/load/gamerules.mcfunction
+++ b/data/commun/functions/load/gamerules.mcfunction
@@ -3,7 +3,7 @@
 # Elle contient les gamerules.
 #
 # Type d'activation : load
-# Activateur(s) : load.mcfunction
+# Activateur(s) : "commun:load"
 #
 # Tags utilisés :
 #

--- a/data/commun/functions/load/scores.mcfunction
+++ b/data/commun/functions/load/scores.mcfunction
@@ -25,6 +25,7 @@ scoreboard objectives add communFullMoved dummy
 scoreboard objectives add communMoveX dummy
 scoreboard objectives add communMoveY dummy
 scoreboard objectives add communMoveZ dummy
+scoreboard objectives add communMsgAuto dummy
 scoreboard objectives add leaveGame minecraft.custom:minecraft.leave_game
 scoreboard objectives add minecraftAnimals minecraft.custom:minecraft.animals_bred
 scoreboard objectives add minecraftAviate minecraft.custom:minecraft.aviate_one_cm

--- a/data/commun/functions/load/scores.mcfunction
+++ b/data/commun/functions/load/scores.mcfunction
@@ -3,7 +3,7 @@
 # Elle contient tous les scores du serveur.
 #
 # Type d'activation : load
-# Activateur(s) : load.mcfunction
+# Activateur(s) : "commun:load"
 #
 # Tags utiliés :
 #

--- a/data/commun/functions/load/teams.mcfunction
+++ b/data/commun/functions/load/teams.mcfunction
@@ -3,7 +3,7 @@
 # Elle contient toutes les teams du serveur.
 #
 # Type d'activation : load
-# Activateur(s) : load.mcfunction
+# Activateur(s) : "commun:load"
 #
 # Tags utiliés :
 #

--- a/data/commun/functions/load/variables.mcfunction
+++ b/data/commun/functions/load/variables.mcfunction
@@ -4,7 +4,7 @@
 # Le nom du score des entiers est "i" ; il est très rapide à écire, et très facile à mémoriser !
 #
 # Type d'activation : load
-# Activateur(s) : load.mcfunction
+# Activateur(s) : "commun:load"
 #
 # Tag(s) utilisé(s):
 #

--- a/data/commun/functions/messages_auto.mcfunction
+++ b/data/commun/functions/messages_auto.mcfunction
@@ -1,0 +1,30 @@
+# ==================================================================================================
+# Cette fonction sert à envoyer régulièrement des messages dans le chat.
+#
+# Type d'activation : tick
+# Activateur(s) : "tick.json"
+#
+# Tag(s) utilisé(s) :
+#
+# ==================================================================================================
+
+# Envoi des messages
+# Discord (Hey ! Le serveur est aussi sur Discord !)
+execute if score communMsgAuto communMsgAuto matches 3600.. if score communMsgAutoId communMsgAuto matches 0 as @a run tellraw @s ["",{"text":"                                                                                ","strikethrough":true,"color":"dark_gray"},{"text":"\n"},{"text":"Hey,","color":"green","clickEvent":{"action":"open_url","value":"https://discord.gg/vqRNfaC"}},{"text":" ","clickEvent":{"action":"open_url","value":"https://discord.gg/vqRNfaC"}},{"selector":"@s","clickEvent":{"action":"open_url","value":"https://discord.gg/vqRNfaC"}},{"text":" ! Rejoins le Discord d'Aycraft !\nPlus on est de fous, plus on rit !","color":"green","clickEvent":{"action":"open_url","value":"https://discord.gg/vqRNfaC"}},{"text":"\n","clickEvent":{"action":"open_url","value":"https://discord.gg/vqRNfaC"}},{"text":"discord.gg/vqRNfaC","color":"blue","clickEvent":{"action":"open_url","value":"https://discord.gg/vqRNfaC"}},{"text":"\n"},{"text":"                                                                                ","strikethrough":true,"color":"dark_gray"},{"text":"\n "}]
+
+# GitHub (Hey ! N'hésitez pas à visiter le GitHub [...])
+execute if score communMsgAuto communMsgAuto matches 3600.. if score communMsgAutoId communMsgAuto matches 1 as @a run tellraw @s ["",{"text":"                                                                                ","strikethrough":true,"color":"dark_gray"},{"text":"\n"},{"text":"Hey,","color":"aqua","clickEvent":{"action":"open_url","value":"https://github.com/Aycraft/"}},{"text":" ","clickEvent":{"action":"open_url","value":"https://github.com/Aycraft/"}},{"selector":"@s","clickEvent":{"action":"open_url","value":"https://github.com/Aycraft/"}},{"text":" ! N'hésites pas à visiter notre GitHub !\nTu pourrais y décourvir plein de choses !","color":"aqua","clickEvent":{"action":"open_url","value":"https://github.com/Aycraft/"}},{"text":"\n","clickEvent":{"action":"open_url","value":"https://github.com/Aycraft/"}},{"text":"https://github.com/Aycraft/","color":"blue","clickEvent":{"action":"open_url","value":"https://github.com/Aycraft/"}},{"text":"\n"},{"text":"                                                                                ","strikethrough":true,"color":"dark_gray"},{"text":"\n "}]
+
+# Blague (C'est [...])
+execute if score communMsgAuto communMsgAuto matches 3600.. if score communMsgAutoId communMsgAuto matches 2 as @a run tellraw @s ["",{"text":"                                                                                ","strikethrough":true,"color":"dark_gray"},{"text":"\n"},{"text":"Insérer une blague ici....","color":"yellow"},{"text":"\n"},{"text":"                                                                                ","strikethrough":true,"color":"dark_gray"},{"text":"\n "}]
+
+# Tip (Saviez vous que [...])
+execute if score communMsgAuto communMsgAuto matches 3600.. if score communMsgAutoId communMsgAuto matches 3 as @a run tellraw @s ["",{"text":"                                                                                ","strikethrough":true,"color":"dark_gray"},{"text":"\n"},{"text":"Savais-tu que cette version du serveur est la 7e !?!","color":"light_purple"},{"text":"\n"},{"text":"                                                                                ","strikethrough":true,"color":"dark_gray"},{"text":"\n "}]
+
+# Stats du serv (joueur[s] connecté[s], etc...) PLUS TARD
+
+# Gestion du score
+execute if score communMsgAuto communMsgAuto matches 3600.. run scoreboard players reset communMsgAuto
+execute unless score communMsgAuto communMsgAuto matches 3600.. run scoreboard players add communMsgAuto communMsgAuto 1
+execute if score communMsgAuto communMsgAuto matches 3600.. run scoreboard players add communMsgAutoId communMsgAuto 1
+execute unless score communMsgAutoId communMsgAuto matches ..3 run scoreboard players set communMsgAutoId communMsgAuto 0

--- a/data/commun/functions/messages_auto.mcfunction
+++ b/data/commun/functions/messages_auto.mcfunction
@@ -2,7 +2,7 @@
 # Cette fonction sert à envoyer régulièrement des messages dans le chat.
 #
 # Type d'activation : tick
-# Activateur(s) : "tick.json"
+# Activateur(s) : "minecraft:tick"
 #
 # Tag(s) utilisé(s) :
 #

--- a/data/commun/functions/outils/protection.mcfunction
+++ b/data/commun/functions/outils/protection.mcfunction
@@ -1,15 +1,12 @@
-#========================================
-# Mode de déclenchement :
-	# Event
-
-# Fonction du fichier :
-	# Assure la protection aux joueurs qui appellent la fonction.
-
-# Tags utilisés :
-	# ----
-#========================================
-
-
+# ==================================================================================================
+# Cette fonction assure la protection aux joueurs qui l'éxecutent.
+#
+# Type d'activation : event
+# Activateur(s) : non définit
+#
+# Tag(s) utilisé(s) :
+#
+# ==================================================================================================
 
 # Rétablissement de la nourriture
 execute unless entity @s[nbt={foodLevel:20}] run effect give @s saturation 1 255 true

--- a/data/commun/functions/outils/set_uuid.mcfunction
+++ b/data/commun/functions/outils/set_uuid.mcfunction
@@ -2,7 +2,7 @@
 # Cette fonction attribue une "user unique identity" aux joueurs qui l'éxecutent.
 #
 # Type d'activation : event
-# Activateur(s) : non définit
+# Activateur(s) : "commun:connection"
 #
 # Tag(s) utilisé(s) :
 #

--- a/data/commun/functions/outils/teleportation_options.mcfunction
+++ b/data/commun/functions/outils/teleportation_options.mcfunction
@@ -2,7 +2,7 @@
 # Cette fonction gère les rêglages de téléportation des joueurs.
 #
 # Mode de déclenchament : event
-# Déclencheur(s) : "commun:connection"
+# Déclencheur(s) : "commun:connection", "commandes:joueurs/hub"
 #
 # Tags utilisés :
 #

--- a/data/commun/functions/outils/teleportation_options.mcfunction
+++ b/data/commun/functions/outils/teleportation_options.mcfunction
@@ -2,7 +2,7 @@
 # Cette fonction gère les rêglages de téléportation des joueurs.
 #
 # Mode de déclenchament : event
-# Déclencheur(s) : "connection.mcfunction"
+# Déclencheur(s) : "commun:connection"
 #
 # Tags utilisés :
 #

--- a/data/minecraft/functions/load.mcfunction
+++ b/data/minecraft/functions/load.mcfunction
@@ -3,7 +3,7 @@
 # Elle va appeller la fonction d'initialisation de l'ensemble du serveur.
 #
 # Trigger mode: load
-# Trigger(s): load.json
+# Trigger(s): "load.json"
 #
 # Used tags :
 #

--- a/data/minecraft/functions/tick.mcfunction
+++ b/data/minecraft/functions/tick.mcfunction
@@ -22,5 +22,6 @@ execute if entity @a run function spawn:bossbar
 scoreboard players enable @a cmdRunCmd
 scoreboard players enable @a cmdRunStaffCmd
 execute as @a if score @s cmdRunCmd matches 1.. run function commandes:cmd
-execute as @a if score @s cmdRunStaffCmd matches 1.. run function commandes:staff_cmd
+execute as @a if score @s cmdRunStaffCmd matches 1.. run function commandes:cmd_staff
+execute as @a if score @s cmdRunCmd matches 1.. run function commandes:cmd_joueurs
 execute if entity @a run function commandes:cmd_effects

--- a/data/minecraft/functions/tick.mcfunction
+++ b/data/minecraft/functions/tick.mcfunction
@@ -21,7 +21,7 @@ execute if entity @a run function spawn:bossbar
 # Execution des commandes personnalisées
 scoreboard players enable @a cmdRunCmd
 scoreboard players enable @a cmdRunStaffCmd
-execute as @a if score @s cmdRunCmd matches 1.. run function commandes:cmd
-execute as @a if score @s cmdRunStaffCmd matches 1.. run function commandes:cmd_staff
+
 execute as @a if score @s cmdRunCmd matches 1.. run function commandes:cmd_joueurs
+execute as @a if score @s cmdRunStaffCmd matches 1.. run function commandes:cmd_staff
 execute if entity @a run function commandes:cmd_effects

--- a/data/minecraft/functions/tick.mcfunction
+++ b/data/minecraft/functions/tick.mcfunction
@@ -12,6 +12,9 @@
 execute as @a unless score @s UUID matches 1.. run function commun:connection
 execute as @a if score @s leaveGame matches 1.. run function commun:connection
 
+# Envoi des messages automatiques
+execute if entity @a run function commun:messages_auto
+
 # Execution de la bossbar du spawn si des joueurs y sont (à préciser)
 execute if entity @a run function spawn:bossbar
 

--- a/data/spawn/functions/bossbar.mcfunction
+++ b/data/spawn/functions/bossbar.mcfunction
@@ -2,7 +2,7 @@
 # Elle gère la bossbar du spawn.
 #
 # Type d'activation : tick
-# Activateur(s) : "tick.mcfunction"
+# Activateur(s) : "minecraft:tick"
 #
 # Tag(s) utilisé(s) :
 #

--- a/data/spawn/functions/bossbar/changement.mcfunction
+++ b/data/spawn/functions/bossbar/changement.mcfunction
@@ -2,7 +2,7 @@
 # Elle gère les changements de la bossbar du spawn.
 #
 # Type d'activation : event
-# Activateur(s) : "bossbar.mcfunction"
+# Activateur(s) : "spawn:bossbar"
 #
 # Tag(s) utilisé(s) :
 #

--- a/data/spawn/functions/bossbar/creation.mcfunction
+++ b/data/spawn/functions/bossbar/creation.mcfunction
@@ -2,7 +2,7 @@
 # Elle gère la création de la bossbar du spawn.
 #
 # Type d'activation : event
-# Activateur(s) : "bossbar.mcfunction"
+# Activateur(s) : "spawn:bossbar"
 #
 # Tag(s) utilisé(s) :
 #

--- a/data/spawn/functions/load.mcfunction
+++ b/data/spawn/functions/load.mcfunction
@@ -3,7 +3,7 @@
 # Il appellera les fonctions du fichier du spawn "load".
 #
 # Type d'activation : load
-# Activateur(s) : "load.json"
+# Activateur(s) : "minecraft:load"
 #
 # Tag(s) utilisé(s) :
 #

--- a/data/spawn/functions/load/scores.mcfunction
+++ b/data/spawn/functions/load/scores.mcfunction
@@ -3,7 +3,7 @@
 # Elle contient tous les scores relatifs au spawn.
 #
 # Type d'activation : load
-# Activateur(s) : "load"
+# Activateur(s) : "spawn:load"
 #
 # Tag(s) utilisé(s) :
 #

--- a/data/stats/functions/load.mcfunction
+++ b/data/stats/functions/load.mcfunction
@@ -3,7 +3,7 @@
 # Elle va appeller la fonction d'initialisation de l'ensemble des statistiques.
 #
 # Mode d'activation : load
-# Activateur(s) : "load.json"
+# Activateur(s) : "minecraft:load"
 #
 # Tags utilisés :
 #

--- a/data/stats/functions/load/grades.mcfunction
+++ b/data/stats/functions/load/grades.mcfunction
@@ -94,6 +94,33 @@ team modify Assistant nametagVisibility always
 team modify Assistant prefix ["",{"text":"Assistant ","color":"aqua","bold":"true"},{"text":"» ","color":"gray"}]
 team modify Assistant seeFriendlyInvisibles false
 
+team add Test-Ingenieur
+team modify Test-Ingenieur collisionRule never
+team modify Test-Ingenieur color white
+team modify Test-Ingenieur deathMessageVisibility never
+team modify Test-Ingenieur friendlyFire true
+team modify Test-Ingenieur nametagVisibility always
+team modify Test-Ingenieur prefix ["",{"text":"Test-Ingénieur ","color":"green","bold":"true"},{"text":"» ","color":"gray"}]
+team modify Test-Ingenieur seeFriendlyInvisibles false
+
+team add Test-Builder
+team modify Test-Builder collisionRule never
+team modify Test-Builder color white
+team modify Test-Builder deathMessageVisibility never
+team modify Test-Builder friendlyFire true
+team modify Test-Builder nametagVisibility always
+team modify Test-Builder prefix ["",{"text":"Test-Builder ","color":"dark_aqua","bold":"true"},{"text":"» ","color":"gray"}]
+team modify Test-Builder seeFriendlyInvisibles false
+
+team add Test-Moderateur
+team modify Test-Moderateur collisionRule never
+team modify Test-Moderateur color white
+team modify Test-Moderateur deathMessageVisibility never
+team modify Test-Moderateur friendlyFire true
+team modify Test-Moderateur nametagVisibility always
+team modify Test-Moderateur prefix ["",{"text":"Test-Modérateur ","color":"yellow","bold":"true"},{"text":"» ","color":"gray"}]
+team modify Test-Moderateur seeFriendlyInvisibles false
+
 team add Legende
 team modify Legende collisionRule never
 team modify Legende color white
@@ -111,6 +138,15 @@ team modify Hero friendlyFire true
 team modify Hero nametagVisibility always
 team modify Hero prefix ["",{"text":"Héro ","color":"light_purple"},{"text":"» ","color":"gray"}]
 team modify Hero seeFriendlyInvisibles false
+
+team add Test-Youtubeur
+team modify Test-Youtubeur collisionRule never
+team modify Test-Youtubeur color white
+team modify Test-Youtubeur deathMessageVisibility never
+team modify Test-Youtubeur friendlyFire true
+team modify Test-Youtubeur nametagVisibility always
+team modify Test-Youtubeur prefix ["",{"text":"Youtubeur ","color":"red"},{"text":"» ","color":"gray"}]
+team modify Test-Youtubeur seeFriendlyInvisibles false
 
 team add MVP++
 team modify MVP++ collisionRule never

--- a/data/stats/functions/load/grades.mcfunction
+++ b/data/stats/functions/load/grades.mcfunction
@@ -19,7 +19,7 @@ team modify Fondateur color white
 team modify Fondateur deathMessageVisibility never
 team modify Fondateur friendlyFire true
 team modify Fondateur nametagVisibility always
-team modify Fondateur prefix ["",{"text":"Fondateur ","color":"gold","bold":"true"},{"text":" » ","color":"gray"}]
+team modify Fondateur prefix ["",{"text":"Fondateur ","color":"gold","bold":"true"},{"text":"» ","color":"gray"}]
 team modify Fondateur seeFriendlyInvisibles false
 
 team add Administrateur
@@ -28,7 +28,7 @@ team modify Administrateur color white
 team modify Administrateur deathMessageVisibility never
 team modify Administrateur friendlyFire true
 team modify Administrateur nametagVisibility always
-team modify Administrateur prefix ["",{"text":"Admin ","color":"dark_red","bold":"true"},{"text":" » ","color":"gray"}]
+team modify Administrateur prefix ["",{"text":"Admin ","color":"dark_red","bold":"true"},{"text":"» ","color":"gray"}]
 team modify Administrateur seeFriendlyInvisibles false
 
 team add Chef-Ingenieur
@@ -37,7 +37,7 @@ team modify Chef-Ingenieur color white
 team modify Chef-Ingenieur deathMessageVisibility never
 team modify Chef-Ingenieur friendlyFire true
 team modify Chef-Ingenieur nametagVisibility always
-team modify Chef-Ingenieur prefix ["",{"text":"Chef-Ingénieur ","color":"dark_green","bold":"true"},{"text":" » ","color":"gray"}]
+team modify Chef-Ingenieur prefix ["",{"text":"Chef-Ingénieur ","color":"dark_green","bold":"true"},{"text":"» ","color":"gray"}]
 team modify Chef-Ingenieur seeFriendlyInvisibles false
 
 team add Chef-Builder
@@ -46,7 +46,7 @@ team modify Chef-Builder color white
 team modify Chef-Builder deathMessageVisibility never
 team modify Chef-Builder friendlyFire true
 team modify Chef-Builder nametagVisibility always
-team modify Chef-Builder prefix ["",{"text":"Chef-Builder ","color":"blue","bold":"true"},{"text":" » ","color":"gray"}]
+team modify Chef-Builder prefix ["",{"text":"Chef-Builder ","color":"blue","bold":"true"},{"text":"» ","color":"gray"}]
 team modify Chef-Builder seeFriendlyInvisibles false
 
 team add Chef-Moderateur
@@ -55,7 +55,7 @@ team modify Chef-Moderateur color white
 team modify Chef-Moderateur deathMessageVisibility never
 team modify Chef-Moderateur friendlyFire true
 team modify Chef-Moderateur nametagVisibility always
-team modify Chef-Moderateur prefix ["",{"text":"Chef-Modérateur ","color":"red","bold":"true"},{"text":" » ","color":"gray"}]
+team modify Chef-Moderateur prefix ["",{"text":"Chef-Modérateur ","color":"red","bold":"true"},{"text":"» ","color":"gray"}]
 team modify Chef-Moderateur seeFriendlyInvisibles false
 
 team add Ingenieur
@@ -64,7 +64,7 @@ team modify Ingenieur color white
 team modify Ingenieur deathMessageVisibility never
 team modify Ingenieur friendlyFire true
 team modify Ingenieur nametagVisibility always
-team modify Ingenieur prefix ["",{"text":"Ingénieur ","color":"green","bold":"true"},{"text":" » ","color":"gray"}]
+team modify Ingenieur prefix ["",{"text":"Ingénieur ","color":"green","bold":"true"},{"text":"» ","color":"gray"}]
 team modify Ingenieur seeFriendlyInvisibles false
 
 team add Builder
@@ -73,7 +73,7 @@ team modify Builder color white
 team modify Builder deathMessageVisibility never
 team modify Builder friendlyFire true
 team modify Builder nametagVisibility always
-team modify Builder prefix ["",{"text":"Builder ","color":"dark_aqua","bold":"true"},{"text":" » ","color":"gray"}]
+team modify Builder prefix ["",{"text":"Builder ","color":"dark_aqua","bold":"true"},{"text":"» ","color":"gray"}]
 team modify Builder seeFriendlyInvisibles false
 
 team add Moderateur
@@ -82,7 +82,7 @@ team modify Moderateur color white
 team modify Moderateur deathMessageVisibility never
 team modify Moderateur friendlyFire true
 team modify Moderateur nametagVisibility always
-team modify Moderateur prefix ["",{"text":"Modérateur ","color":"yellow","bold":"true"},{"text":" » ","color":"gray"}]
+team modify Moderateur prefix ["",{"text":"Modérateur ","color":"yellow","bold":"true"},{"text":"» ","color":"gray"}]
 team modify Moderateur seeFriendlyInvisibles false
 
 team add Assistant
@@ -91,7 +91,7 @@ team modify Assistant color white
 team modify Assistant deathMessageVisibility never
 team modify Assistant friendlyFire true
 team modify Assistant nametagVisibility always
-team modify Assistant prefix ["",{"text":"Assistant ","color":"aqua","bold":"true"},{"text":" » ","color":"gray"}]
+team modify Assistant prefix ["",{"text":"Assistant ","color":"aqua","bold":"true"},{"text":"» ","color":"gray"}]
 team modify Assistant seeFriendlyInvisibles false
 
 team add Legende
@@ -100,7 +100,7 @@ team modify Legende color white
 team modify Legende deathMessageVisibility never
 team modify Legende friendlyFire true
 team modify Legende nametagVisibility always
-team modify Legende prefix ["",{"text":"Légende ","color":"dark_purple"},{"text":" » ","color":"gray"}]
+team modify Legende prefix ["",{"text":"Légende ","color":"dark_purple"},{"text":"» ","color":"gray"}]
 team modify Legende seeFriendlyInvisibles false
 
 team add Hero
@@ -109,7 +109,7 @@ team modify Hero color white
 team modify Hero deathMessageVisibility never
 team modify Hero friendlyFire true
 team modify Hero nametagVisibility always
-team modify Hero prefix ["",{"text":"Héro ","color":"light_purple"},{"text":" » ","color":"gray"}]
+team modify Hero prefix ["",{"text":"Héro ","color":"light_purple"},{"text":"» ","color":"gray"}]
 team modify Hero seeFriendlyInvisibles false
 
 team add MVP++
@@ -118,7 +118,7 @@ team modify MVP++ color white
 team modify MVP++ deathMessageVisibility never
 team modify MVP++ friendlyFire true
 team modify MVP++ nametagVisibility always
-team modify MVP++ prefix ["",{"text":"MVP++ ","color":"gold"},{"text":" » ","color":"gray"}]
+team modify MVP++ prefix ["",{"text":"MVP++ ","color":"gold"},{"text":"» ","color":"gray"}]
 team modify MVP++ seeFriendlyInvisibles false
 
 team add MVP+
@@ -127,7 +127,7 @@ team modify MVP+ color white
 team modify MVP+ deathMessageVisibility never
 team modify MVP+ friendlyFire true
 team modify MVP+ nametagVisibility always
-team modify MVP+ prefix ["",{"text":"MVP+ ","color":"dark_aqua"},{"text":" » ","color":"gray"}]
+team modify MVP+ prefix ["",{"text":"MVP+ ","color":"dark_aqua"},{"text":"» ","color":"gray"}]
 team modify MVP+ seeFriendlyInvisibles false
 
 team add MVP
@@ -136,7 +136,7 @@ team modify MVP color white
 team modify MVP deathMessageVisibility never
 team modify MVP friendlyFire true
 team modify MVP nametagVisibility always
-team modify MVP prefix ["",{"text":"MVP ","color":"dark_aqua"},{"text":" » ","color":"gray"}]
+team modify MVP prefix ["",{"text":"MVP ","color":"dark_aqua"},{"text":"» ","color":"gray"}]
 team modify MVP seeFriendlyInvisibles false
 
 team add Ami
@@ -145,7 +145,7 @@ team modify Ami color white
 team modify Ami deathMessageVisibility never
 team modify Ami friendlyFire true
 team modify Ami nametagVisibility always
-team modify Ami prefix ["",{"text":"Ami ","color":"light_purple"},{"text":" » ","color":"gray"}]
+team modify Ami prefix ["",{"text":"Ami ","color":"light_purple"},{"text":"» ","color":"gray"}]
 team modify Ami seeFriendlyInvisibles false
 
 team add VIP+
@@ -154,7 +154,7 @@ team modify VIP+ color white
 team modify VIP+ deathMessageVisibility never
 team modify VIP+ friendlyFire true
 team modify VIP+ nametagVisibility always
-team modify VIP+ prefix ["",{"text":"VIP+ ","color":"green"},{"text":" » ","color":"gray"}]
+team modify VIP+ prefix ["",{"text":"VIP+ ","color":"green"},{"text":"» ","color":"gray"}]
 team modify VIP+ seeFriendlyInvisibles false
 
 team add VIP
@@ -163,5 +163,5 @@ team modify VIP color white
 team modify VIP deathMessageVisibility never
 team modify VIP friendlyFire true
 team modify VIP nametagVisibility always
-team modify VIP prefix ["",{"text":"VIP ","color":"green"},{"text":" » ","color":"gray"}]
+team modify VIP prefix ["",{"text":"VIP ","color":"green"},{"text":"» ","color":"gray"}]
 team modify VIP seeFriendlyInvisibles false

--- a/data/stats/functions/load/grades.mcfunction
+++ b/data/stats/functions/load/grades.mcfunction
@@ -2,7 +2,7 @@
 # Cette fonction va générer tous les grades utilisés sur le serveur.
 #
 # Mode d'activation : load
-# Activateur(s) : "load"
+# Activateur(s) : "stats:load"
 #
 # Tags utilisés :
 #

--- a/data/stats/functions/load/grades.mcfunction
+++ b/data/stats/functions/load/grades.mcfunction
@@ -139,14 +139,14 @@ team modify Hero nametagVisibility always
 team modify Hero prefix ["",{"text":"Héro ","color":"light_purple"},{"text":"» ","color":"gray"}]
 team modify Hero seeFriendlyInvisibles false
 
-team add Test-Youtubeur
-team modify Test-Youtubeur collisionRule never
-team modify Test-Youtubeur color white
-team modify Test-Youtubeur deathMessageVisibility never
-team modify Test-Youtubeur friendlyFire true
-team modify Test-Youtubeur nametagVisibility always
-team modify Test-Youtubeur prefix ["",{"text":"Youtubeur ","color":"red"},{"text":"» ","color":"gray"}]
-team modify Test-Youtubeur seeFriendlyInvisibles false
+team add Youtubeur
+team modify Youtubeur collisionRule never
+team modify Youtubeur color white
+team modify Youtubeur deathMessageVisibility never
+team modify Youtubeur friendlyFire true
+team modify Youtubeur nametagVisibility always
+team modify Youtubeur prefix ["",{"text":"Youtubeur ","color":"red"},{"text":"» ","color":"gray"}]
+team modify Youtubeur seeFriendlyInvisibles false
 
 team add MVP++
 team modify MVP++ collisionRule never

--- a/data/stats/functions/load/scores.mcfunction
+++ b/data/stats/functions/load/scores.mcfunction
@@ -3,7 +3,7 @@
 # Elle contient tous les scores relatifs aux statistiques.
 #
 # Type d'activation : load
-# Activateur(s) : "load"
+# Activateur(s) : "stats:load"
 #
 # Tag(s) utilisé(s) :
 #


### PR DESCRIPTION
## Informations
+ Ajout des messages automatiques diffusés dans le chat.
+ Correction des activateurs des fonctions.
+ Ajout du grade Test-Builder.
+ Ajout du grade Test-Ingénieur.
+ Ajout du grade Test-Modérateur.
+ Ajout du grade Youtubeur.
+ Ajout de la commande `/hub`, `/spawn`, `/lobby`, `/home` : sert à 
retourner au hub
+ Ajout de la commande `/bug` : sert à obtenir le lien vers la page de 
rapports de bugs
+ Modification du nom du fichier "staff_cmd" en "cmd_staff" dans un but 
pratique et logique
+ Ajout de la commande `/helpop` : sert à demander de l'aide au staff.
+ Ajout de la commande `/god` : sert à se rendre invulnérable.
- Correction d'un bug non-déclaré : le message de téléportation au spawn 
était rouge au lieu de vert.
- Correction d'un bug non-signalé : la team "Youtubeur" s'appellait 
"Test-Youtubeur"
- Correction d'un bug non-signalé ; les préfix des grades comportaient un "espace" de trop.